### PR TITLE
feat: update graphhopper version to 0.11.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
     // add GraphHopper dependency
     // https://github.com/graphhopper/graphhopper/tree/master/android
-    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '0.10.0') {
+    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '0.11.0') {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
         exclude group: 'org.openstreetmap.osmosis', module: 'osmosis-osm-binary'
         exclude group: 'org.apache.xmlgraphics', module: 'xmlgraphics-commons'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 
 # BASE
 
-PARAM_COMPILE_SDK_VERSION = 27
+PARAM_COMPILE_SDK_VERSION = 28
 PARAM_MIN_SDK_VERSION = 15
-PARAM_TARGET_SDK_VERSION = 27
+PARAM_TARGET_SDK_VERSION = 28
 
 # LIBRARIES
 
 # https://developer.android.com/studio/releases/gradle-plugin.html
-ANDROID_PLUGIN_GRADLE = 3.0.1
+ANDROID_PLUGIN_GRADLE = 3.2.0
 # https://developer.android.com/studio/releases/build-tools.html
-ANDROID_BUILD_TOOLS = 27.0.3
+ANDROID_BUILD_TOOLS = 28.0.3
 
 # base support version
-LIB_ANDROID_SUPPORT = 27.1.1
+LIB_ANDROID_SUPPORT = 28.0.0
 # Locus API
 LIB_LOCUS_API = 0.2.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
I updated graphhopper routing data and it is better to release a new version of addon to be sure that routing data is compatible. 

Release notes — https://www.graphhopper.com/blog/2018/09/17/graphhopper-routing-engine-0-11-release-open-sourcing-the-isochrone-module/