### PR TITLE
feat: update graphhopper version to 1.0-pre20

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+ij_any_else_on_new_line = true
+ij_any_block_comment_at_first_column = false
+ij_any_line_comment_at_first_column = false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Add-on for [Locus Map](http://www.locusmap.eu) (Android) application, created to
 
 Add-on is based on [GraphHopper](https://graphhopper.com/) routing system.
 
+Ready to use [routing data](https://graphhopper.develar.org/) is available.
+
 ### Possible improvements
 
 - TODO

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // add GraphHopper dependency
     // https://github.com/graphhopper/graphhopper/tree/master/android
     // https://mvnrepository.com/artifact/com.graphhopper/graphhopper-core
-    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '1.0-pre18') {
+    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '1.0-pre20') {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
         exclude group: 'org.openstreetmap.osmosis', module: 'osmosis-osm-binary'
         exclude group: 'org.apache.xmlgraphics', module: 'xmlgraphics-commons'


### PR DESCRIPTION
Please see https://forum.locusmap.eu/index.php?topic=4036.msg58297#msg58297

>  I can get navigation to work for fast cycle and racing cycle but not for the others. I get T: problem with service on orange toast.

I reproduced error for bayern for hike, and with a new [map](https://s3.eu-central-1.wasabisys.com/gh-routing-data/2020-02-03/bayern-at-cz.osm-gh.zip) (Bayern + Austria + Czech Republic 1.1. GB) and new version, error was fixed.

Please note, that fix https://github.com/graphhopper/graphhopper/pull/1876 is not included into `1.0-pre20`. But it is ok.

> What's more the navigate button seems to need to be tapped twice.

Do you have any idea why?


[app-addonGraphHopper-release.apk.zip](https://github.com/asamm/locus-addon-graphhopper/files/4149676/app-addonGraphHopper-release.apk.zip)
