### PR TITLE
feat: update graphhopper version to 1.0-pre31

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl = https\://services.gradle.org/distributions/gradle-6.1-all.zip
+distributionUrl = https\://services.gradle.org/distributions/gradle-6.2.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,11 +35,11 @@ dependencies {
     // add GraphHopper dependency
     // https://github.com/graphhopper/graphhopper/tree/master/android
     // https://mvnrepository.com/artifact/com.graphhopper/graphhopper-core
-    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '1.0-pre20') {
+    implementation(group: 'com.graphhopper', name: 'graphhopper-core', version: '1.0-pre31') {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
         exclude group: 'org.openstreetmap.osmosis', module: 'osmosis-osm-binary'
         exclude group: 'org.apache.xmlgraphics', module: 'xmlgraphics-commons'
     }
-    implementation 'org.slf4j:slf4j-api:1.7.25'
-    implementation 'org.slf4j:slf4j-android:1.7.25'
+    implementation 'org.slf4j:slf4j-api:1.7.26'
+    implementation 'org.slf4j:slf4j-android:1.7.26'
 }


### PR DESCRIPTION
Important fix: https://github.com/graphhopper/graphhopper/pull/1876 This change allows to reduce code on addon side. The only reason why we have to configure GH instance — elevation. I don't count it as even a minor problem, so, I do not file issue / PR to graphhopper library.

Release notes: https://github.com/graphhopper/graphhopper/releases/tag/1.0-pre26
[app-addonGraphHopper-debug.apk.zip](https://github.com/asamm/locus-addon-graphhopper/files/4298602/app-addonGraphHopper-debug.apk.zip)



I tested it — works for me. No "problem with service" or "double tap" issues. Thanks a lot.

Routing data is already available to use, you just need to select version: see combox "Locus Map Add-on Version" , select `0.10 (unreleased) | Graphhopper 1.0-pre0.26`